### PR TITLE
Update bootstrap version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-uswds-icons-demo",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8088,11 +8088,18 @@
       }
     },
     "ngx-bootstrap-icons": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap-icons/-/ngx-bootstrap-icons-1.5.0.tgz",
-      "integrity": "sha512-/Nnio+7ZboNkpxpc47VuPlSd8aVTw8X18Cug0hwIp4gr+kU3FNuFlg09MtHp/B7zrzVnaYg09ODIiy+KuKV9Ug==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap-icons/-/ngx-bootstrap-icons-1.7.2.tgz",
+      "integrity": "sha512-aTSZM089nSe0wptOp71e56IHSg+sWyiqxsLMaKj2bLqGWLBuWS2CaA2uBZZ92lzttG6UkJw8fi7FNyEQskLsmQ==",
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "nice-napi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-uswds-icons-demo",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "scripts": {
     "ng": "ng",
     "start": "npm run regenerateIcons && ng serve",
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "~12.2.14",
     "@angular/router": "~12.2.14",
     "lodash": "^4.17.21",
-    "ngx-bootstrap-icons": "^1.5.0",
+    "ngx-bootstrap-icons": "^1.7.2",
     "number-to-text": "^0.3.8",
     "replace": "^1.2.1",
     "rxjs": "~6.6.0",

--- a/projects/icons/package.json
+++ b/projects/icons/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@gsa-sam/ngx-uswds-icons",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "types": "../../../dist/out-tsc/projects/icons/index.d.ts",
   "peerDependencies": {
     "@angular/common": "^12.2.14",
     "@angular/core": "^12.2.14"
   },
   "dependencies": {
-    "ngx-bootstrap-icons": "^1.5.0"
+    "ngx-bootstrap-icons": "^1.7.2"
   }
 }


### PR DESCRIPTION
Update ngx-bootstrap-icons dependency to 1.7.2 in order to gain access to additional icons